### PR TITLE
use clientX instead of screenX

### DIFF
--- a/src/components/DragResize/index.js
+++ b/src/components/DragResize/index.js
@@ -90,7 +90,7 @@ class DragResize extends Component {
   }
 
   handleDrag = e => {
-    this.measureX(e.screenX)
+    this.measureX(e.clientX)
   }
 
   handleDragEnd = e => {


### PR DESCRIPTION
it was not related to chrome canary or something exotic
the problem was it worked only when your window was on top left of your screen. arf.

resolve #14